### PR TITLE
Adds ubi-based container image file

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/python-39:1-143.1697647134
+
+# Add application sources with correct permissions for OpenShift
+USER 0
+
+WORKDIR /opt/app-root/src
+ADD . /opt/app-root/src/
+RUN chown -R 1001:0 /opt/app-root/src/
+USER 1001
+
+# Install the dependencies
+RUN pip install -r requirements.txt 
+
+# Run the application
+CMD uvicorn ols:app --host 0.0.0.0


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a Containerfile for building into a container image

## Related Tickets & Documents


## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
I ran it locally via podman using a random UID (`podman run -u 10246 -p 8000:8000 -it --rm quay.io/openshiftdemos/
ols-service:latest`) and was able to successfully access the container.

Note that this container image expects the local vector db files to already be present on the local system. In the future we'll be shipping some kind of real vector store, most likely, so that probably isn't a problem longer-term.